### PR TITLE
add missing standard header to ompBLAS

### DIFF
--- a/src/Platforms/OMPTarget/ompBLAS.cpp
+++ b/src/Platforms/OMPTarget/ompBLAS.cpp
@@ -11,6 +11,7 @@
 
 
 #include "ompBLAS.hpp"
+#include <cstdint>
 #include <stdexcept>
 #include "config.h"
 #if !defined(OPENMP_NO_COMPLEX)


### PR DESCRIPTION
https://github.com/QMCPACK/qmcpack/issues/4792#issuecomment-1775823946

## Proposed changes

Add missing header, otherwise compilation fails in debian:testing

## What type(s) of changes does this code introduce?

- Bugfix
- Refactoring (no functional changes, no api changes)
- Build related changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

## Checklist

- Yes This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
