### PR TITLE
correct implementation of uninitialized_copy_n for shmem

### DIFF
--- a/src/AFQMC/Memory/SharedMemory/shm_ptr_with_raw_ptr_dispatch.hpp
+++ b/src/AFQMC/Memory/SharedMemory/shm_ptr_with_raw_ptr_dispatch.hpp
@@ -488,12 +488,11 @@ It2 uninitialized_copy_n(shm_ptr_with_raw_ptr_dispatch<T> f, Size n, It2 d)
   f.wSP_->fence();
   using std::uninitialized_copy_n;
   if (f.wSP_->get_group().root())
-    uninitialized_copy_n(f, n, to_address(d));
+    uninitialized_copy_n(to_address(f), n, to_address(d));
   f.wSP_->fence();
   mpi3::communicator(f.wSP_->get_group(), 0).barrier();
   return d + n;
 }
-
 
 template<class Alloc, class It1, class Size, typename T>
 shm_ptr_with_raw_ptr_dispatch<T> uninitialized_copy_n(Alloc& a, It1 f, Size n, shm_ptr_with_raw_ptr_dispatch<T> d)


### PR DESCRIPTION
## Proposed changes

uninitialized_copy_n for shmem was implemented in the wrong way preventing an update of Multi

## What type(s) of changes does this code introduce?

- Bugfix (silent bug)
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Ubuntu 22.04

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
