### PR TITLE
only use this overload if semantically correct

### DIFF
--- a/src/AFQMC/Memory/device_pointers.hpp
+++ b/src/AFQMC/Memory/device_pointers.hpp
@@ -526,7 +526,11 @@ device_pointer<T> copy_n(device_pointer<T const> const A, Size n, device_pointer
 */
 
 template<typename T, typename ForwardIt, typename Size>
-device_pointer<T> copy_n(ForwardIt A, Size n, device_pointer<T> B)
+auto copy_n(ForwardIt A, Size n, device_pointer<T> B)
+// AAC: only use this overload if it is semantically correct 
+// (e.g., A is not a fancy pointer -- in continuous memory);
+// and if not, there will be other candidates, possibly provided by Multi itself (e.g. through ADL priority)
+-> decltype(arch::memcopy(to_address(B), to_address(A), n * sizeof(T)), B + n) 
 {
   arch::memcopy(to_address(B), to_address(A), n * sizeof(T));
   return B + n;


### PR DESCRIPTION
(e.g. A is not a fancy pointer -- in continuous memory); and if not, there will be other candidates, possibly provided by Multi itself (e.g. through ADL priority)

AFQMC used to provide its own fancy memory specializations.
Some of these function do not work for iterators that are not fancy pointers themselves, giving a hard error.

## Proposed changes

Use decltype to remove the overload if not semantically correct

## What type(s) of changes does this code introduce?

- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Ubuntu 22.04 and CUDA 12

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed

