### PR TITLE
[ppconvert] Update Blitz.h to use ADL get

### DIFF
--- a/src/QMCTools/ppconvert/src/common/Blitz.h
+++ b/src/QMCTools/ppconvert/src/common/Blitz.h
@@ -76,7 +76,7 @@ struct Array : base_type
   Array(int rs, int cs) : base_type({rs, cs}) {}
   std::ptrdiff_t extent(int d) const
   {
-    using std::get  // prevents the need for C++20 extensions in C++17
+    using std::get;  // prevents the need for C++20 extensions in C++17
     switch (d)
     {
     case 0:

--- a/src/QMCTools/ppconvert/src/common/Blitz.h
+++ b/src/QMCTools/ppconvert/src/common/Blitz.h
@@ -76,18 +76,19 @@ struct Array : base_type
   Array(int rs, int cs) : base_type({rs, cs}) {}
   std::ptrdiff_t extent(int d) const
   {
+    using std::get  // prevents the need for C++20 extensions in C++17
     switch (d)
     {
     case 0:
-      return std::get<0>(base_type::sizes());
+      return get<0>(base_type::sizes());
     case 1:
-      return std::get<1>(base_type::sizes());
+      return get<1>(base_type::sizes());
     }
     assert(false);
     return 0;
   }
-  auto rows() const { return std::get<0>(base_type::sizes()); }
-  auto cols() const { return std::get<1>(base_type::sizes()); }
+  auto rows() const { using std::get; return get<0>(base_type::sizes()); }  // using std::get prevents the need for C++20 extensions in C++17
+  auto cols() const { using std::get; return get<1>(base_type::sizes()); }  // using std::get prevents the need for C++20 extensions in C++17
   void resize(int rs, int cs) { base_type::reextent({rs, cs}); }
   using sizes_type = decltype(std::declval<base_type const&>().sizes());
   sizes_type shape() const { return base_type::sizes(); }
@@ -149,8 +150,9 @@ struct Array<T, 1, base_type> : base_type
   {
     switch (d)
     {
+      using std::get;  // prevents the need for C++20 extensions in C++17
     case 0:
-      return std::get<0>(base_type::sizes());
+      return get<0>(base_type::sizes());
     }
     assert(false);
     return 0;

--- a/src/QMCTools/ppconvert/src/common/IOVarASCII.h
+++ b/src/QMCTools/ppconvert/src/common/IOVarASCII.h
@@ -348,7 +348,8 @@ inline void IOVarASCII<T, RANK>::Resize(int n)
 {
   //  TinyVector<int, RANK>
   auto dims         = ArrayValue.shape();
-  std::get<0>(dims) = n;
+  using std::get;
+  get<0>(dims) = n;
   //  dims[0]                    = n;
   ArrayValue.resizeAndPreserve(dims);
 }


### PR DESCRIPTION
## Proposed changes

use modified interface of Multi that doesn't rely in UB by specializing std::get in namespace std.

## What type(s) of changes does this code introduce?

- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Ubuntu gitlab CI

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
